### PR TITLE
adding account history page

### DIFF
--- a/UI/account-history.html
+++ b/UI/account-history.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="/UI/CSS/style.css">
+    <title>Login</title>
+</head>
+<body>
+    <header>
+        <div class="main">
+        <div class="logo">
+            <img src="/UI/assets/download (1).jpg" alt="">
+        </div>
+         <div class="header"> 
+            <ul>
+                <li class="active"> <a href="/index.html">Home</a> </li>
+                <li> <a href="login.html">logout</a> </li>
+                <!-- <li> <a href="sign-up.html">sign up</a> </li> -->
+                <li> <a href="account-history.html">account history</a> </li>
+            </ul>
+        </div> 
+        
+        <div class="required">
+            <div class="our-need" >
+                <p>new entry</p> <br>
+                <p>add entry</p> <br>
+                <p>delete entry</p><br>
+               <p>edit entry</p> <br>
+                    
+            </div>
+            <div class="your-entry">
+                <textarea name="your dairy" id="1" cols="50" rows="20"></textarea> <br>
+                    <button class="buttons" type="submit">save </button><br> 
+                </div> 
+        </div>  
+
+</header>
+
+
+
+        <div class="footer">
+            <h2>Copyright Dairy@2019</h2>
+        </div> 
+        
+</body>
+</html>


### PR DESCRIPTION
What does this PR do?
- add account history form
 - add footer and background image 
Description of Task to be completed
- A user should be able to see the entry page on this page where user should be able to see how they can add a new entry, edit, delete and save her works, they are redirected to the account history page.
How should this be manually tested?
- clone the repo and switch to the branch ft-account-history-167193582

enter details in the field and click on the image as a link for more details

- you should be successfully redirected to account-history.html

What are the relevant pivotal tracker stories?
- 1688192857
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/50420731/64021975-fd342a80-cb99-11e9-82e7-cb63027b19a1.png)

#### Questions: