### PR TITLE
modify account history page and css

### DIFF
--- a/UI/CSS/style.css
+++ b/UI/CSS/style.css
@@ -118,7 +118,7 @@ input[type=text],input[type=password], input[type=email]{
     margin: 5px;
     font-weight: bold;
 }
-input[type=submit]{
+.types{
     width: 100%;
     box-sizing: border-box;
     padding: 10px 0;
@@ -131,9 +131,13 @@ input[type=submit]{
     font-size: 20px;
     color: #fff;
 }
-input[type=submit]:hover{
+.types a:hover{
     background: #003366;
     opacity: 0.7;
+}
+.types a{
+    text-decoration: none;
+    color: #fff;
 }
 #main{
     text-decoration: #ddd4d4;

--- a/UI/CSS/style.css
+++ b/UI/CSS/style.css
@@ -215,30 +215,8 @@ form label{
      flex-wrap: wrap;
      margin-top: 100px;
      
+}
 
-}
- .our-need{
-    justify-content: flex-start;
-    background: grey;
-    padding: 10px;
-    border: 1em;
-    
-} 
-.our-need p{
-    justify-content: flex-start;
-    justify-items: center;
-    color: bisque;
-    padding: 20px;
-    text-transform: uppercase;
-   
-    
-
-}
-.your-entry{
-    display: inline-flexbox;
-    background: #546354;
-    flex-wrap: wrap;
-}
 .buttons{
     padding: 10px;
     margin-left: 120px;

--- a/UI/CSS/style.css
+++ b/UI/CSS/style.css
@@ -217,14 +217,6 @@ form label{
      
 }
 
-.buttons{
-    padding: 10px;
-    margin-left: 120px;
-    text-transform: uppercase;
-    
-}
-
-
 
 /*footer*/
 .footer{

--- a/UI/account-history.html
+++ b/UI/account-history.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="stylesheet" href="/UI/CSS/style.css">
-    <title>Login</title>
+    <title>account history</title>
 </head>
 <body>
     <header>
@@ -17,24 +17,26 @@
             <ul>
                 <li class="active"> <a href="/index.html">Home</a> </li>
                 <li> <a href="login.html">logout</a> </li>
-                <!-- <li> <a href="sign-up.html">sign up</a> </li> -->
+                 <li> <a href="sign-up.html">sign up</a> </li> 
                 <li> <a href="account-history.html">account history</a> </li>
             </ul>
         </div> 
         
-        <div class="required">
-            <div class="our-need" >
-                <p>new entry</p> <br>
-                <p>add entry</p> <br>
-                <p>delete entry</p><br>
-               <p>edit entry</p> <br>
-                    
-            </div>
-            <div class="your-entry">
-                <textarea name="your dairy" id="1" cols="50" rows="20"></textarea> <br>
-                    <button class="buttons" type="submit">save </button><br> 
-                </div> 
-        </div>  
+        <div class="wraps">
+            <img class="images" src="/UI/assets/149086-essential-set.png" alt="">
+        <h2>sign in here</h2>
+        <form >
+      <input type="email" placeholder="Email.." >
+      <input type="text" placeholder="Username..">
+      <input type="password" placeholder="password.."> 
+      <button class="types"> <a href="/UI/entry.html">save</a> </button>
+  
+        
+
+</form>
+
+</div>
+
 
 </header>
 


### PR DESCRIPTION
#### What does this PR do?
- change page of account history
#### Description of Task to be completed?
- user should be able to login before accessing the account history, restricted on the account history page
#### How should this be manually tested?
- clone the repo and switch to the branch ft-account history-168192857

- enter details in the field and click save

- you should be successfully redirected to account-history.html
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
-168192857
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/50420731/64068270-b4b06600-cc9a-11e9-8094-60604fe4d93b.png)

#### Questions